### PR TITLE
feat: add static Yaomexi Studio landing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,69 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  color-scheme: light dark;
+  --font-size-base: clamp(1rem, 0.95rem + 0.2vw, 1.125rem);
+  --font-size-lg: clamp(1.125rem, 1rem + 0.5vw, 1.5rem);
+  --font-size-xl: clamp(1.5rem, 1.25rem + 1vw, 2.5rem);
+  --radius-md: 0.75rem;
+}
+
+body {
+  font-family: 'Inter', 'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: var(--font-size-base);
+  background-color: theme('colors.neutral.50');
+  color: theme('colors.neutral.900');
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.dark body {
+  background-color: theme('colors.brand.night');
+  color: theme('colors.neutral.50');
+}
+
+h1,
+ h2,
+ h3,
+ h4,
+ h5,
+ h6 {
+  font-family: 'DM Sans', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button,
+ input,
+ select,
+ textarea {
+  font: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid theme('colors.brand.gold');
+  outline-offset: 3px;
+}
+
+.container-responsive {
+  width: min(100%, 1100px);
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 0.5rem + 2vw, 2.5rem);
+}
+
+section {
+  padding-block: clamp(3rem, 2rem + 4vw, 5rem);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import './globals.css'
+
+const navigation = [
+  { href: '/', label: 'Inicio' },
+  { href: '/historias', label: 'Historias' },
+  { href: '/videos', label: 'Videos' },
+  { href: '/impacto', label: 'Impacto' },
+  { href: '/nfts', label: 'NFTs' },
+  { href: '/comunidad', label: 'Comunidad' }
+]
+
+export const metadata: Metadata = {
+  title: 'Yaomexikatl Studio',
+  description:
+    'Creando historias y experiencias digitales que financian la reforestación de especies nativas en México.'
+}
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="es" className="bg-neutral-50 text-neutral-900 dark:bg-brand-night dark:text-neutral-50">
+      <body className="flex min-h-screen flex-col font-body antialiased">
+        <header className="sticky top-0 z-50 border-b border-neutral-200 bg-white/80 backdrop-blur dark:border-neutral-800 dark:bg-brand-night/80">
+          <div className="container-responsive flex items-center justify-between py-4">
+            <Link href="/" className="flex items-center gap-3 font-display text-lg font-semibold text-brand-jade">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-turquoise text-lg text-white">
+                YX
+              </span>
+              <div className="flex flex-col leading-tight">
+                <span>Yaomexikatl</span>
+                <span className="text-sm font-medium text-neutral-500 dark:text-neutral-300">Historias que siembran</span>
+              </div>
+            </Link>
+            <nav aria-label="Navegación principal">
+              <ul className="flex items-center gap-6 text-sm font-medium text-neutral-700 dark:text-neutral-200">
+                {navigation.map((item) => (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className="transition-colors hover:text-brand-turquoise focus-visible:text-brand-turquoise"
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </div>
+        </header>
+        <main className="flex-1">{children}</main>
+        <footer className="border-t border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-brand-night/60">
+          <div className="container-responsive grid gap-6 py-10 md:grid-cols-3">
+            <div>
+              <h2 className="font-display text-lg text-brand-jade">Nuestra misión</h2>
+              <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
+                Impulsamos historias, cómics y experiencias digitales que honran la cultura prehispánica, protegen a los
+                colibríes y financian la reforestación de plantas y árboles nativos.
+              </p>
+            </div>
+            <div>
+              <h2 className="font-display text-lg text-brand-jade">Síguenos</h2>
+              <ul className="mt-3 space-y-2 text-sm text-neutral-600 dark:text-neutral-300">
+                <li>
+                  <a href="https://www.tiktok.com/@yaomexikatl" target="_blank" rel="noreferrer" className="hover:text-brand-turquoise">
+                    TikTok
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.instagram.com/yaomexikatl"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="hover:text-brand-turquoise"
+                  >
+                    Instagram
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <h2 className="font-display text-lg text-brand-jade">Transparencia</h2>
+              <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
+                Cada compra financia plantas y árboles nativos. Pronto podrás seguir los reportes de impacto en tiempo real
+                y auditar nuestros proyectos de reforestación.
+              </p>
+            </div>
+          </div>
+        </footer>
+      </body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link'
+import { BadgeImpact } from '../components/BadgeImpact'
+
+const storytellingThemes = [
+  {
+    title: 'Mitos y leyendas',
+    description:
+      'Rescatamos relatos ancestrales y los transformamos en narrativas modernas que inspiran a las nuevas generaciones.'
+  },
+  {
+    title: 'Colibríes y polinizadores',
+    description:
+      'Creamos contenidos que celebran a los guardianes del equilibrio ecológico y promueven su conservación.'
+  },
+  {
+    title: 'Cultura y cuidado ambiental',
+    description:
+      'Conectamos tradiciones prehispánicas con acciones actuales para proteger bosques y selvas de México.'
+  }
+]
+
+export default function HomePage() {
+  return (
+    <>
+      <section className="bg-gradient-to-b from-brand-night via-brand-night/95 to-neutral-100 text-neutral-50 dark:from-brand-night dark:via-brand-night">
+        <div className="container-responsive flex flex-col gap-10 py-20 md:flex-row md:items-center">
+          <div className="flex-1 space-y-6">
+            <BadgeImpact />
+            <h1 className="text-4xl font-bold leading-tight md:text-5xl">Historias de México que siembran futuro</h1>
+            <p className="max-w-xl text-lg text-neutral-100/90">
+              Crea videos gratis para TikTok y pronto para YouTube; apoya reforestación con cada producto digital.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                href="/videos/crear"
+                className="inline-flex items-center justify-center rounded-full bg-brand-turquoise px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-turquoise/30 transition hover:bg-brand-jade focus-visible:bg-brand-jade"
+              >
+                Crear video de TikTok
+              </Link>
+              <Link
+                href="/impacto"
+                className="inline-flex items-center justify-center rounded-full border border-brand-gold px-6 py-3 text-sm font-semibold text-brand-gold transition hover:border-brand-turquoise hover:text-brand-turquoise focus-visible:border-brand-turquoise"
+              >
+                Ver impacto
+              </Link>
+            </div>
+          </div>
+          <div className="flex-1 rounded-3xl bg-white/10 p-8 backdrop-blur-lg shadow-xl shadow-brand-night/20">
+            <p className="text-sm uppercase tracking-[0.3em] text-brand-gold">Estrategia Yaomexikatl</p>
+            <p className="mt-4 text-lg text-neutral-50/90">
+              Cultura prehispánica, colibríes y reforestación se unen para crear una comunidad creativa que financia bosques
+              nativos mediante cómics, videos, NFTs y transparencia radical.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="como-funciona" className="bg-neutral-50 dark:bg-brand-night">
+        <div className="container-responsive space-y-10">
+          <div className="max-w-2xl">
+            <h2 id="como-funciona" className="font-display text-3xl text-brand-jade">
+              ¿Cómo funciona?
+            </h2>
+            <p className="mt-4 text-neutral-600 dark:text-neutral-300">
+              Diseñamos una experiencia rápida para que tus contenidos inspiren acción climática en cuestión de minutos.
+            </p>
+          </div>
+          <ol className="grid gap-6 md:grid-cols-3">
+            {['Elige plantilla', 'Genera guion/voz', 'Publica y apoya'].map((step, index) => (
+              <li
+                key={step}
+                className="flex flex-col gap-4 rounded-2xl border border-neutral-200 bg-white/70 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-neutral-800 dark:bg-brand-night/60"
+              >
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-turquoise text-sm font-semibold text-white">
+                  {index + 1}
+                </span>
+                <h3 className="font-display text-xl text-brand-jade">{step}</h3>
+                <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                  {index === 0 && 'Selecciona la historia visual ideal para TikTok o Reels.'}
+                  {index === 1 && 'Recibe un guion y voz listos para grabar o animar tu video.'}
+                  {index === 2 && 'Publica, comparte y destina las ganancias a la reforestación.'}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section aria-labelledby="tematicas" className="bg-white dark:bg-brand-night/80">
+        <div className="container-responsive space-y-8">
+          <div className="max-w-2xl">
+            <h2 id="tematicas" className="font-display text-3xl text-brand-jade">
+              Temáticas que inspiran
+            </h2>
+            <p className="mt-4 text-neutral-600 dark:text-neutral-300">
+              Nuestra biblioteca digital honra la biodiversidad y la memoria de los pueblos originarios de México.
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {storytellingThemes.map((theme) => (
+              <article
+                key={theme.title}
+                className="flex flex-col gap-3 rounded-2xl border border-neutral-200 bg-neutral-50 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-neutral-800 dark:bg-brand-night/50"
+              >
+                <h3 className="font-display text-xl text-brand-jade">{theme.title}</h3>
+                <p className="text-sm text-neutral-600 dark:text-neutral-300">{theme.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/app/videos/crear/page.tsx
+++ b/app/videos/crear/page.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+const steps = [
+  { id: 1, title: 'Plantilla' },
+  { id: 2, title: 'Guion' },
+  { id: 3, title: 'Voz y música' }
+]
+
+export default function CrearVideoPage() {
+  const [currentStep, setCurrentStep] = useState(1)
+  const [selectedTemplate, setSelectedTemplate] = useState('')
+  const [script, setScript] = useState('')
+  const [selectedVoice, setSelectedVoice] = useState('')
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const progress = useMemo(() => (currentStep / steps.length) * 100, [currentStep])
+
+  const canAdvance = useMemo(() => {
+    if (currentStep === 1) {
+      return selectedTemplate.length > 0
+    }
+    if (currentStep === 2) {
+      return script.trim().length >= 50
+    }
+    return selectedVoice.length > 0
+  }, [currentStep, script, selectedTemplate, selectedVoice])
+
+  const handleNext = () => {
+    if (!canAdvance) {
+      setFormError('Por favor completa la información requerida antes de continuar.')
+      return
+    }
+    setFormError(null)
+    setCurrentStep((prev) => Math.min(prev + 1, steps.length))
+  }
+
+  const handlePrevious = () => {
+    setFormError(null)
+    setCurrentStep((prev) => Math.max(prev - 1, 1))
+  }
+
+  const handleAutoGenerate = () => {
+    console.info('stub')
+    setFormError('Generador automático disponible próximamente. Puedes escribir tu guion manualmente.')
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canAdvance) {
+      setFormError('Revisa la información antes de enviar tu historia.')
+      return
+    }
+    // TODO: Conectar a FastAPI vía /backend/* cuando esté habilitado
+    console.info('Wizard listo para enviar al backend', {
+      template: selectedTemplate,
+      script,
+      voice: selectedVoice
+    })
+  }
+
+  return (
+    <section className="bg-neutral-50 pb-20 pt-16 dark:bg-brand-night">
+      <div className="container-responsive">
+        <div className="rounded-3xl border border-neutral-200 bg-white/80 p-8 shadow-lg dark:border-neutral-800 dark:bg-brand-night/60">
+          <header className="space-y-4">
+            <p className="text-sm font-medium uppercase tracking-widest text-brand-gold">Crea tu video</p>
+            <h1 className="font-display text-3xl text-brand-jade">Lanza historias listas para TikTok 9:16 en 60 segundos</h1>
+            <p className="text-sm text-neutral-600 dark:text-neutral-300">
+              Comparte relatos de colibríes y culturas ancestrales mientras financias la reforestación de especies nativas.
+            </p>
+          </header>
+
+          <div className="mt-8">
+            <div className="h-2 rounded-full bg-neutral-200 dark:bg-neutral-800">
+              <div className="h-2 rounded-full bg-brand-turquoise transition-all" style={{ width: `${progress}%` }} />
+            </div>
+            <ol className="mt-6 flex flex-wrap items-center gap-4 text-sm font-medium text-neutral-600 dark:text-neutral-300">
+              {steps.map((step) => (
+                <li key={step.id} className="flex items-center gap-2">
+                  <span
+                    className={`flex h-8 w-8 items-center justify-center rounded-full border text-sm font-semibold ${
+                      currentStep === step.id
+                        ? 'border-brand-turquoise bg-brand-turquoise text-white'
+                        : 'border-neutral-300 bg-white text-neutral-600 dark:border-neutral-700 dark:bg-transparent'
+                    }`}
+                    aria-current={currentStep === step.id ? 'step' : undefined}
+                  >
+                    {step.id}
+                  </span>
+                  <span>{step.title}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <form className="mt-8 space-y-8" onSubmit={handleSubmit} noValidate>
+            {currentStep === 1 && (
+              <fieldset className="space-y-4">
+                <legend className="font-display text-2xl text-brand-jade">Selecciona una plantilla</legend>
+                <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                  Elige la narrativa que mejor conecte con tu audiencia. Ajustaremos duración y ritmo automáticamente.
+                </p>
+                <label
+                  className={`flex cursor-pointer flex-col gap-2 rounded-2xl border p-6 transition focus-within:ring-2 focus-within:ring-brand-gold focus-within:ring-offset-2 dark:border-neutral-700 ${
+                    selectedTemplate === 'tiktok-vertical'
+                      ? 'border-brand-turquoise bg-brand-turquoise/10'
+                      : 'border-neutral-200 bg-white/70 dark:bg-brand-night/60'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="template"
+                    value="tiktok-vertical"
+                    checked={selectedTemplate === 'tiktok-vertical'}
+                    onChange={(event) => setSelectedTemplate(event.target.value)}
+                    className="sr-only"
+                  />
+                  <span className="text-sm font-semibold uppercase tracking-widest text-brand-gold">TikTok</span>
+                  <span className="font-display text-xl text-brand-jade">Formato vertical 9:16</span>
+                  <span className="text-sm text-neutral-600 dark:text-neutral-300">Duración estimada: 60 segundos.</span>
+                </label>
+              </fieldset>
+            )}
+
+            {currentStep === 2 && (
+              <fieldset className="space-y-4">
+                <legend className="font-display text-2xl text-brand-jade">Construye tu guion</legend>
+                <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                  Describe las escenas clave que conecten cultura, biodiversidad y llamado a la acción.
+                </p>
+                <textarea
+                  required
+                  value={script}
+                  onChange={(event) => setScript(event.target.value)}
+                  rows={8}
+                  className="w-full rounded-2xl border border-neutral-200 bg-white/80 p-4 text-sm text-neutral-800 shadow-sm transition focus:border-brand-turquoise focus:outline-none focus:ring-2 focus:ring-brand-gold dark:border-neutral-700 dark:bg-brand-night/60 dark:text-neutral-100"
+                  placeholder="Ejemplo: Introduce la leyenda del colibrí mensajero, explica su rol como polinizador y cierra con la invitación a apoyar la reforestación."
+                  aria-describedby="script-hint"
+                />
+                <div className="flex flex-wrap items-center gap-4 text-sm">
+                  <button
+                    type="button"
+                    onClick={handleAutoGenerate}
+                    className="rounded-full border border-brand-turquoise px-5 py-2 font-semibold text-brand-turquoise transition hover:bg-brand-turquoise hover:text-white focus-visible:bg-brand-turquoise focus-visible:text-white"
+                  >
+                    Auto-generar
+                  </button>
+                  <p id="script-hint" className="text-neutral-500 dark:text-neutral-400">
+                    Recomendamos al menos 50 caracteres para mantener una narrativa clara.
+                  </p>
+                </div>
+              </fieldset>
+            )}
+
+            {currentStep === 3 && (
+              <fieldset className="space-y-4">
+                <legend className="font-display text-2xl text-brand-jade">Selecciona voz o música</legend>
+                <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                  Define el estilo sonoro para reforzar el mensaje y la emoción de tu historia.
+                </p>
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200" htmlFor="voice">
+                  Voz narrativa
+                </label>
+                <select
+                  id="voice"
+                  required
+                  value={selectedVoice}
+                  onChange={(event) => setSelectedVoice(event.target.value)}
+                  className="w-full rounded-full border border-neutral-200 bg-white/80 px-4 py-3 text-sm text-neutral-800 shadow-sm transition focus:border-brand-turquoise focus:outline-none focus:ring-2 focus:ring-brand-gold dark:border-neutral-700 dark:bg-brand-night/60 dark:text-neutral-100"
+                >
+                  <option value="" disabled>
+                    Selecciona una voz
+                  </option>
+                  <option value="voz-femenina">
+                    Voz femenina cálida (español latino)
+                  </option>
+                  <option value="voz-masculina">
+                    Voz masculina serena (español latino)
+                  </option>
+                  <option value="instrumental">
+                    Solo música instrumental con sonidos de naturaleza
+                  </option>
+                </select>
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center rounded-full bg-brand-jade px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-turquoise focus-visible:bg-brand-turquoise"
+                >
+                  Enviar
+                </button>
+              </fieldset>
+            )}
+
+            {formError && <p className="text-sm text-brand-red" role="alert">{formError}</p>}
+
+            <div className="flex items-center justify-between border-t border-neutral-200 pt-6 dark:border-neutral-800">
+              <button
+                type="button"
+                onClick={handlePrevious}
+                disabled={currentStep === 1}
+                className="inline-flex items-center justify-center rounded-full border border-neutral-300 px-5 py-2 text-sm font-medium text-neutral-600 transition hover:border-brand-turquoise hover:text-brand-turquoise disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:text-neutral-300"
+              >
+                Atrás
+              </button>
+              {currentStep < steps.length && (
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  className="inline-flex items-center justify-center rounded-full bg-brand-turquoise px-6 py-2 text-sm font-semibold text-white transition hover:bg-brand-jade focus-visible:bg-brand-jade"
+                >
+                  Continuar
+                </button>
+              )}
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/BadgeImpact.tsx
+++ b/components/BadgeImpact.tsx
@@ -1,0 +1,11 @@
+export function BadgeImpact() {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-brand-turquoise/50 bg-brand-turquoise/10 px-4 py-2 text-sm font-medium text-brand-jade">
+      <span className="h-2.5 w-2.5 rounded-full bg-brand-turquoise" aria-hidden="true" />
+      <span>
+        Árboles financiados:{' '}
+        <span className="ml-1 font-semibold tabular-nums text-brand-turquoise">0000</span>
+      </span>
+    </div>
+  )
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Yaomexi Studio | Historias de México que siembran futuro</title>
+    <meta
+      name="description"
+      content="Yaomexi Studio crea historias, videos y experiencias digitales que financian la reforestación con especies nativas de México."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container header-inner">
+        <a class="brand" href="#inicio" aria-label="Yaomexi Studio inicio">Yaomexi Studio</a>
+        <nav aria-label="Navegación principal">
+          <ul>
+            <li><a href="#inicio">Inicio</a></li>
+            <li><a href="#historias">Historias</a></li>
+            <li><a href="#videos">Videos</a></li>
+            <li><a href="#impacto">Impacto</a></li>
+            <li><a href="#nfts">NFTs</a></li>
+            <li><a href="#comunidad">Comunidad</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <section id="inicio" class="hero">
+        <div class="container hero-grid">
+          <div>
+            <span class="hero-badge" role="status" aria-live="polite">Árboles financiados: 0000</span>
+            <h1>Historias de México que siembran futuro</h1>
+            <p>
+              Crea videos gratis para TikTok y pronto para YouTube; apoya la reforestación con cada
+              producto digital inspirado en la cultura prehispánica y los colibríes que la resguardan.
+            </p>
+            <div class="cta-group">
+              <a class="button button-primary" href="/videos/crear">Crear video de TikTok</a>
+              <a class="button button-secondary" href="/impacto">Ver impacto</a>
+            </div>
+            <div class="impact-badge" id="impacto">
+              <span>Transparencia en tiempo real:</span>
+              <span class="highlight">cada compra financia plantas y árboles nativos.</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="videos" class="section">
+        <div class="container">
+          <header class="section-header">
+            <p class="section-subtitle">Wizard creativo 3 pasos</p>
+            <h2 class="section-title">Crea tu video listo para TikTok en minutos</h2>
+            <p class="section-subtitle">
+              Nuestro generador combina guiones basados en mitos y leyendas con voces y música inspiradas
+              en la naturaleza para amplificar la cultura y el impacto ambiental.
+            </p>
+          </header>
+          <div class="steps" role="list">
+            <article class="step-card" role="listitem">
+              <strong>Paso 1 — Elige plantilla</strong>
+              <p>Selecciona formato TikTok 9:16 de 60 segundos para contar tu historia con ritmo ágil.</p>
+            </article>
+            <article class="step-card" role="listitem">
+              <strong>Paso 2 — Genera guion y voz</strong>
+              <p>
+                Escribe tu idea o usa la opción <em>Auto-generar</em> para recibir un guion narrado con
+                tonos que honran a la biodiversidad.
+              </p>
+            </article>
+            <article class="step-card" role="listitem">
+              <strong>Paso 3 — Voz y música</strong>
+              <p>
+                Escoge voces y paisajes sonoros de colibríes y bosques mesófilos y comparte al instante con
+                tu comunidad.
+              </p>
+            </article>
+          </div>
+          <p class="section-subtitle" role="note">
+            TODO: Conectar a FastAPI vía <code>/backend/*</code> cuando esté habilitado.
+          </p>
+        </div>
+      </section>
+
+      <section id="historias" class="section">
+        <div class="container">
+          <header class="section-header">
+            <h2 class="section-title">Historias que polinizan imaginación e impacto</h2>
+            <p class="section-subtitle">
+              Inspiramos con narrativas que conectan el legado prehispánico, los colibríes y la reforestación
+              regenerativa.
+            </p>
+          </header>
+          <div class="content-grid" role="list">
+            <article class="content-card" role="listitem">
+              <h3>Mitos y leyendas</h3>
+              <p>
+                Relatos ancestrales revitalizados en formatos digitales que invitan a las audiencias jóvenes
+                a proteger sus raíces.
+              </p>
+            </article>
+            <article class="content-card" role="listitem">
+              <h3>Colibríes y polinizadores</h3>
+              <p>
+                Historias que muestran la importancia de los colibríes como guardianes del equilibrio y
+                aliados de la reforestación.
+              </p>
+            </article>
+            <article class="content-card" role="listitem">
+              <h3>Cultura y cuidado ambiental</h3>
+              <p>
+                Experiencias que unen arte, ciencia y participación comunitaria para restaurar bosques y
+                selvas nativas.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="nfts" class="section">
+        <div class="container">
+          <header class="section-header">
+            <h2 class="section-title">Coleccionables digitales con propósito</h2>
+            <p class="section-subtitle">
+              Lanzamos cómics, NFTs y contenido audiovisual que financian viveros locales y documentan el
+              impacto con transparencia radical.
+            </p>
+          </header>
+        </div>
+      </section>
+
+      <section id="comunidad" class="section">
+        <div class="container">
+          <header class="section-header">
+            <h2 class="section-title">Comunidad Yaomexikatl</h2>
+            <p class="section-subtitle">
+              Únete a creadores, guardianes y aliados que comparten tutoriales, transmisiones en vivo y
+              reportes de impacto en TikTok, Instagram y YouTube.
+            </p>
+          </header>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <h2>Yaomexi Studio</h2>
+          <p>
+            Combinamos cultura prehispánica, colibríes y tecnologías creativas para financiar la
+            reforestación de especies nativas en México.
+          </p>
+          <p class="transparency">Cada compra financia plantas y árboles nativos.</p>
+        </div>
+        <div>
+          <h2>Redes sociales</h2>
+          <p>Sigue nuestras historias en TikTok e Instagram.</p>
+          <div class="social-links">
+            <a href="https://www.tiktok.com" aria-label="TikTok" target="_blank" rel="noreferrer">Tt</a>
+            <a href="https://www.instagram.com" aria-label="Instagram" target="_blank" rel="noreferrer">Ig</a>
+            <a href="https://www.youtube.com" aria-label="YouTube" target="_blank" rel="noreferrer">Yt</a>
+          </div>
+        </div>
+        <div>
+          <h2>Transparencia</h2>
+          <p>Consulta reportes mensuales de impacto y alianzas comunitarias.</p>
+          <p class="footer-note">Pronto integraremos panel público con métricas verificadas.</p>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,403 @@
+:root {
+  color-scheme: light dark;
+  --color-jade: #0f766e;
+  --color-turquoise: #14b8a6;
+  --color-gold: #f59e0b;
+  --color-red: #ef4444;
+  --color-night: #0b1020;
+  --color-surface: #f8fafc;
+  --color-surface-dark: #111827;
+  --color-text: #0f172a;
+  --color-text-muted: #334155;
+  --color-border: rgba(15, 23, 42, 0.1);
+  --color-border-dark: rgba(148, 163, 184, 0.2);
+  --shadow-soft: 0 20px 45px -24px rgba(15, 23, 42, 0.4);
+  --radius-lg: 1.25rem;
+  --radius-md: 1rem;
+  --radius-sm: 0.75rem;
+  --font-body: "Inter", "DM Sans", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --font-heading: "DM Sans", "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-surface: #0b1120;
+    --color-surface-dark: #020617;
+    --color-text: #e2e8f0;
+    --color-text-muted: #cbd5f5;
+    --color-border: rgba(148, 163, 184, 0.2);
+    --shadow-soft: 0 20px 45px -24px rgba(15, 23, 42, 0.7);
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--color-text);
+  background: linear-gradient(180deg, var(--color-surface) 0%, #ffffff 35%, var(--color-surface) 100%);
+  min-height: 100vh;
+}
+
+main {
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--color-turquoise);
+  outline-offset: 3px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.container {
+  width: min(100% - 2.5rem, 1160px);
+  margin-inline: auto;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+@media (prefers-color-scheme: dark) {
+  header {
+    background: rgba(11, 17, 32, 0.92);
+    border-bottom-color: var(--color-border);
+  }
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0.5rem;
+}
+
+.brand {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: clamp(1.3rem, 1.2rem + 0.4vw, 1.6rem);
+  color: var(--color-jade);
+  letter-spacing: 0.02em;
+}
+
+nav ul {
+  display: flex;
+  gap: clamp(0.75rem, 0.5rem + 1vw, 1.75rem);
+  align-items: center;
+}
+
+nav a {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus-visible {
+  color: var(--color-jade);
+  background: rgba(20, 184, 166, 0.12);
+}
+
+.hero {
+  padding: clamp(4rem, 8vw, 7.5rem) 0 clamp(3rem, 6vw, 6rem);
+}
+
+.hero-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(15, 118, 110, 0.12);
+  color: var(--color-jade);
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.2);
+}
+
+.hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.3rem, 1.8rem + 2.4vw, 3.6rem);
+  line-height: 1.1;
+  margin: 1.25rem 0 1rem;
+}
+
+.hero p {
+  font-size: clamp(1.05rem, 0.95rem + 0.6vw, 1.3rem);
+  color: var(--color-text-muted);
+  max-width: 36rem;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, var(--color-jade), var(--color-turquoise));
+  color: #ffffff;
+  box-shadow: 0 16px 30px -18px rgba(20, 184, 166, 0.9);
+}
+
+.button-secondary {
+  background: rgba(11, 16, 32, 0.05);
+  color: var(--color-night);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.1);
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  background: rgba(11, 16, 32, 0.12);
+  color: var(--color-jade);
+}
+
+.button-primary:hover,
+.button-primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 36px -18px rgba(20, 184, 166, 0.9);
+}
+
+.impact-badge {
+  margin-top: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(120deg, rgba(15, 118, 110, 0.18), rgba(245, 158, 11, 0.18));
+  color: var(--color-night);
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.25);
+}
+
+.section {
+  padding: clamp(3rem, 5vw, 5rem) 0;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: clamp(2rem, 3vw, 3rem);
+}
+
+.section-title {
+  font-family: var(--font-heading);
+  font-size: clamp(1.8rem, 1.4rem + 1.5vw, 2.6rem);
+  line-height: 1.2;
+}
+
+.section-subtitle {
+  color: var(--color-text-muted);
+  max-width: 36rem;
+}
+
+.steps {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.step-card {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.step-card strong {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+  color: var(--color-jade);
+}
+
+.step-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.content-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.content-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.content-card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--color-night);
+}
+
+.content-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.highlight {
+  font-weight: 700;
+  color: var(--color-gold);
+}
+
+footer {
+  background: var(--color-night);
+  color: #f1f5f9;
+  padding: clamp(2.5rem, 4vw, 4rem) 0;
+}
+
+.footer-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+footer h2 {
+  font-size: 1.2rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-family: var(--font-heading);
+}
+
+footer p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.social-links {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.social-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #f8fafc;
+  font-weight: 700;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.social-links a:hover,
+.social-links a:focus-visible {
+  background: rgba(20, 184, 166, 0.6);
+  transform: translateY(-2px);
+}
+
+.footer-note {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.transparency {
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-gold);
+}
+
+@media (max-width: 768px) {
+  nav ul {
+    gap: 0.65rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero {
+    padding-top: 4.5rem;
+  }
+
+  .cta-group {
+    width: 100%;
+  }
+
+  .button {
+    flex: 1 1 240px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,17 +1,36 @@
 import type { Config } from 'tailwindcss'
+import colors from 'tailwindcss/colors'
 
 export default {
-  content: ['./src/**/*.{ts,tsx}', './src/app/**/*.{ts,tsx}'],
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {
-        yaoGreen: '#2E7D32',
-        yaoGold: '#C7A73D',
-        yaoDark: '#0F0F0F'
+        brand: {
+          jade: '#0F766E',
+          turquoise: '#14B8A6',
+          gold: '#F59E0B',
+          red: '#EF4444',
+          night: '#0B1020'
+        },
+        neutral: {
+          50: colors.slate[50],
+          100: colors.slate[100],
+          200: colors.slate[200],
+          300: colors.slate[300],
+          400: colors.slate[400],
+          500: colors.zinc[500],
+          600: colors.zinc[600],
+          700: colors.zinc[700],
+          800: colors.zinc[800],
+          900: colors.zinc[900],
+          950: colors.zinc[950]
+        }
       },
       fontFamily: {
-        display: ['ui-sans-serif', 'system-ui', 'Segoe UI', 'Roboto'],
-        body: ['ui-sans-serif', 'system-ui', 'Segoe UI', 'Roboto']
+        display: ['"DM Sans"', 'Inter', 'ui-sans-serif', 'system-ui'],
+        body: ['Inter', '"DM Sans"', 'ui-sans-serif', 'system-ui']
       }
     }
   },


### PR DESCRIPTION
## Summary
- introduce standalone CSS design system capturing Yaomexikatl palette, typography, and responsive utilities for the static landing
- craft an accessible, responsive index.html landing mirroring hero, storytelling, impact, and community sections from the previous prompt with transparency messaging

## Testing
- not run (static HTML/CSS only)


------
https://chatgpt.com/codex/tasks/task_b_68d31d5ca5708325889f2c870b3c78a9