### PR TITLE
Handle duplicate clip uploads in mini studio

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,8 +5,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 from uuid import uuid4
+import json
 
-from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi import Depends, FastAPI, File, HTTPException, Request, UploadFile, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
@@ -15,8 +16,11 @@ from redis.asyncio import Redis
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 QUEUE_NAME = os.getenv("QUEUE_NAME", "yaomexi:videos")
 JOB_KEY_PREFIX = os.getenv("JOB_KEY_PREFIX", "video_job:")
+UPLOAD_KEY_PREFIX = os.getenv("UPLOAD_KEY_PREFIX", "editor_upload:")
 VIDEOS_DIR = Path(os.getenv("VIDEOS_DIR", "/videos"))
+UPLOADS_DIR = Path(os.getenv("UPLOADS_DIR", VIDEOS_DIR / "uploads"))
 VIDEOS_DIR.mkdir(parents=True, exist_ok=True)
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 
 ORIGINS = ["http://localhost:3000", "https://yaomexicatl.mx"]
 
@@ -31,6 +35,21 @@ class CreateTikTokVideoRequest(BaseModel):
     template: str = Field(..., min_length=3)
     script: str = Field(..., min_length=50)
     voice: str = Field(..., min_length=3)
+
+
+class UploadClipResponse(BaseModel):
+    upload_id: str
+    filename: str
+    size: int
+
+
+class TimelineClip(BaseModel):
+    upload_id: str = Field(..., min_length=3)
+    duration: float = Field(..., gt=0)
+
+
+class CreateTimelineJobRequest(BaseModel):
+    clips: list[TimelineClip] = Field(..., min_length=1)
 
 
 class JobStatusResponse(BaseModel):
@@ -63,6 +82,93 @@ async def healthcheck() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.post("/editor/uploads", response_model=UploadClipResponse, status_code=status.HTTP_201_CREATED)
+async def upload_editor_clip(
+    file: UploadFile = File(...), redis: Redis = Depends(redis_dependency)
+) -> UploadClipResponse:
+    if file.content_type and not file.content_type.startswith("video/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Solo se permiten archivos de video.",
+        )
+
+    data = await file.read()
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El archivo de video está vacío.",
+        )
+
+    upload_id = uuid4().hex
+    suffix = Path(file.filename or "").suffix or ".mp4"
+    destination = UPLOADS_DIR / f"{upload_id}{suffix}"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(data)
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    clip_key = f"{UPLOAD_KEY_PREFIX}{upload_id}"
+    await redis.hset(
+        clip_key,
+        mapping={
+            "upload_id": upload_id,
+            "original_filename": file.filename or "",
+            "path": destination.as_posix(),
+            "size": str(len(data)),
+            "created_at": timestamp,
+        },
+    )
+    await redis.expire(clip_key, 60 * 60 * 24)
+
+    await file.close()
+    return UploadClipResponse(
+        upload_id=upload_id,
+        filename=file.filename or destination.name,
+        size=len(data),
+    )
+
+
+@app.post("/editor/jobs", status_code=status.HTTP_202_ACCEPTED, response_model=JobStatusResponse)
+async def create_timeline_job(
+    payload: CreateTimelineJobRequest, redis: Redis = Depends(redis_dependency)
+) -> JobStatusResponse:
+    for clip in payload.clips:
+        clip_key = f"{UPLOAD_KEY_PREFIX}{clip.upload_id}"
+        exists = await redis.exists(clip_key)
+        if not exists:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"El clip {clip.upload_id} no fue encontrado o expiró.",
+            )
+
+    job_id = uuid4().hex
+    timestamp = datetime.now(timezone.utc).isoformat()
+    job_key = f"{JOB_KEY_PREFIX}{job_id}"
+    total_duration = sum(clip.duration for clip in payload.clips)
+
+    mapping = {
+        "job_id": job_id,
+        "status": "QUEUED",
+        "job_type": "timeline",
+        "clips": json.dumps([clip.model_dump() for clip in payload.clips]),
+        "total_duration": str(total_duration),
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "download_url": "",
+        "message": "",
+    }
+
+    await redis.hset(job_key, mapping=mapping)
+    await redis.expire(job_key, 60 * 60 * 24)
+    await redis.rpush(QUEUE_NAME, job_id)
+
+    return JobStatusResponse(
+        job_id=job_id,
+        status="QUEUED",
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+
 @app.post("/videos/tiktok", status_code=status.HTTP_202_ACCEPTED, response_model=JobStatusResponse)
 async def create_tiktok_video(
     payload: CreateTikTokVideoRequest, redis: Redis = Depends(redis_dependency)
@@ -74,6 +180,7 @@ async def create_tiktok_video(
     mapping = {
         "job_id": job_id,
         "status": "QUEUED",
+        "job_type": "tiktok",
         "template": payload.template,
         "script": payload.script,
         "voice": payload.voice,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link'
 import './globals.css'
 
 const navigation = [
-  { href: '/',          label: 'Inicio' },
+  { href: '/', label: 'Inicio' },
   { href: '/historias', label: 'Historias' },
-  { href: '/studio',    label: 'Videos' },
-  { href: '/impacto',   label: 'Impacto' },
-  { href: '/nfts',      label: 'NFTs' },
+  { href: '/studio', label: 'Videos' },
+  { href: '/impacto', label: 'Impacto' },
+  { href: '/nfts', label: 'NFTs' },
   { href: '/comunidad', label: 'Comunidad' },
 ]
 
@@ -29,28 +29,56 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html
-      lang="es"
-      className="bg-neutral-50 text-neutral-900 dark:bg-brand-night dark:text-neutral-50"
-    >
+    <html lang="es" className="bg-neutral-50 text-neutral-900 dark:bg-brand-night dark:text-neutral-50">
       <body className="flex min-h-screen flex-col font-body antialiased">
         <header className="sticky top-0 z-50 border-b border-neutral-200 bg-white/80 backdrop-blur dark:border-neutral-800 dark:bg-brand-night/80">
           <div className="container-responsive flex items-center justify-between py-4">
-            <Link
-              href="/"
-              className="flex items-center gap-3 font-display text-lg font-semibold text-brand-jade"
-            >
+            <Link href="/" className="flex items-center gap-3 font-display text-lg font-semibold text-brand-jade">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-turquoise text-lg text-white">
                 YX
               </span>
               <div className="flex flex-col leading-tight">
                 <span>Yaomexicatl</span>
-                <span className="text-sm font-medium text-neutral-500 dark:text-neutral-300">
-                  Historias que siembran
-                </span>
+                <span className="text-sm font-medium text-neutral-500 dark:text-neutral-300">Historias que siembran</span>
               </div>
             </Link>
 
             <nav aria-label="Navegación principal">
-              <ul className="flex items-center gap-6 text-sm font-medium
+              <ul className="flex items-center gap-6 text-sm font-medium text-neutral-600 dark:text-neutral-200">
+                {navigation.map(({ href, label }) => (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      className="transition hover:text-brand-turquoise focus-visible:text-brand-turquoise"
+                    >
+                      {label}
+                    </Link>
+                  </li>
+                ))}
+                <li>
+                  <Link
+                    href="/studio/editor"
+                    className="inline-flex items-center justify-center rounded-full bg-brand-jade px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-turquoise focus-visible:bg-brand-turquoise"
+                  >
+                    Crear video de TikTok
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </header>
 
+        <main className="flex-1">{children}</main>
+
+        <footer className="border-t border-neutral-200 bg-white/60 py-6 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-brand-night/70 dark:text-neutral-300">
+          <div className="container-responsive flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <p>© {new Date().getFullYear()} Yaomexicatl Studio. Reforestando con historias.</p>
+            <p className="text-xs uppercase tracking-[0.3em] text-brand-gold">
+              Transparencia: cada creación financia plantas nativas.
+            </p>
+          </div>
+        </footer>
+      </body>
+    </html>
+  )
+}

--- a/app/studio/editor/EditorClient.tsx
+++ b/app/studio/editor/EditorClient.tsx
@@ -1,0 +1,434 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+const ACCEPTED_TYPES = ['video/mp4', 'video/quicktime', 'video/webm']
+
+function createFileFingerprint(file: File): string {
+  return [file.name, file.size, file.lastModified].join('::')
+}
+
+function formatSeconds(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds)) {
+    return '0:00'
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.round(totalSeconds % 60)
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+type LocalClip = {
+  localId: string
+  file: File
+  objectUrl: string
+  duration?: number
+  uploadId?: string
+  status: 'uploading' | 'uploaded' | 'error'
+  error?: string | null
+}
+
+type UploadResponse = {
+  upload_id: string
+  filename: string
+  size: number
+}
+
+type JobResponse = {
+  job_id: string
+}
+
+function createLocalId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+async function extractDuration(objectUrl: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video')
+    video.preload = 'metadata'
+    video.src = objectUrl
+
+    const handleLoadedMetadata = () => {
+      resolve(video.duration)
+      cleanup()
+    }
+
+    const handleError = () => {
+      reject(new Error('No se pudo leer la duración del video.'))
+      cleanup()
+    }
+
+    const cleanup = () => {
+      video.removeEventListener('loadedmetadata', handleLoadedMetadata)
+      video.removeEventListener('error', handleError)
+      video.src = ''
+    }
+
+    video.addEventListener('loadedmetadata', handleLoadedMetadata)
+    video.addEventListener('error', handleError)
+  })
+}
+
+export function EditorClient() {
+  const router = useRouter()
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const objectUrlsRef = useRef<Set<string>>(new Set<string>())
+  const [clips, setClips] = useState<LocalClip[]>([])
+  const [renderError, setRenderError] = useState<string | null>(null)
+  const [isRendering, setIsRendering] = useState(false)
+
+  useEffect(() => {
+    const urls = objectUrlsRef.current
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url))
+      urls.clear()
+      objectUrlsRef.current = new Set<string>()
+    }
+  }, [])
+
+  const totalDuration = useMemo(() => {
+    return clips.reduce((sum, clip) => sum + (clip.duration ?? 0), 0)
+  }, [clips])
+
+  const handleSelectFiles = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const files = event.target.files
+    if (!files) {
+      return
+    }
+
+    const selectedFiles = Array.from(files)
+    const filtered = selectedFiles.filter((file) =>
+      ACCEPTED_TYPES.includes(file.type)
+    )
+
+    const existingFingerprints = new Set(
+      clips.map((clip) => createFileFingerprint(clip.file))
+    )
+
+    let duplicatesFound = false
+    const uniqueFiles = filtered.filter((file) => {
+      const fingerprint = createFileFingerprint(file)
+      if (existingFingerprints.has(fingerprint)) {
+        duplicatesFound = true
+        return false
+      }
+
+      existingFingerprints.add(fingerprint)
+      return true
+    })
+
+    const messages: string[] = []
+    if (filtered.length !== selectedFiles.length) {
+      messages.push(
+        'Algunos archivos fueron ignorados por no ser videos compatibles (MP4, MOV o WebM).'
+      )
+    }
+
+    if (duplicatesFound) {
+      messages.push('Algunos videos ya estaban cargados y se omitieron duplicados.')
+    }
+
+    setRenderError(messages.length ? messages.join(' ') : null)
+
+    const newClips: LocalClip[] = uniqueFiles.map((file) => {
+      const objectUrl = URL.createObjectURL(file)
+      objectUrlsRef.current.add(objectUrl)
+      return {
+        localId: createLocalId(),
+        file,
+        objectUrl,
+        status: 'uploading',
+      }
+    })
+
+    setClips((previous) => [...previous, ...newClips])
+
+    await Promise.all(
+      newClips.map(async (clip) => {
+        try {
+          const duration = await extractDuration(clip.objectUrl)
+          setClips((previous) =>
+            previous.map((existing) =>
+              existing.localId === clip.localId
+                ? { ...existing, duration }
+                : existing
+            )
+          )
+        } catch (durationError) {
+          console.error(durationError)
+          setClips((previous) =>
+            previous.map((existing) =>
+              existing.localId === clip.localId
+                ? {
+                    ...existing,
+                    status: 'error',
+                    error: 'No se pudo obtener la duración del archivo.',
+                  }
+                : existing
+            )
+          )
+          return
+        }
+
+        try {
+          const formData = new FormData()
+          formData.append('file', clip.file)
+          const response = await fetch('/backend/editor/uploads', {
+            method: 'POST',
+            body: formData,
+          })
+
+          if (!response.ok) {
+            throw new Error(`Error ${response.status}`)
+          }
+
+          const payload = (await response.json()) as UploadResponse
+
+          setClips((previous) =>
+            previous.map((existing) =>
+              existing.localId === clip.localId
+                ? {
+                    ...existing,
+                    uploadId: payload.upload_id,
+                    status: 'uploaded',
+                    error: null,
+                  }
+                : existing
+            )
+          )
+        } catch (uploadError) {
+          console.error('Error al subir el clip', uploadError)
+          setClips((previous) =>
+            previous.map((existing) =>
+              existing.localId === clip.localId
+                ? {
+                    ...existing,
+                    status: 'error',
+                    error:
+                      'No se pudo subir el video. Revisa tu conexión e inténtalo de nuevo.',
+                  }
+                : existing
+            )
+          )
+        }
+      })
+    )
+
+    event.target.value = ''
+  }
+
+  const handleRemoveClip = (localId: string) => {
+    setClips((previous) => {
+      const clipToRemove = previous.find((clip) => clip.localId === localId)
+      if (clipToRemove) {
+        URL.revokeObjectURL(clipToRemove.objectUrl)
+        objectUrlsRef.current.delete(clipToRemove.objectUrl)
+      }
+      return previous.filter((clip) => clip.localId !== localId)
+    })
+  }
+
+  const handleResetError = () => {
+    setRenderError(null)
+  }
+
+  const handleRender = async () => {
+    if (!clips.length) {
+      setRenderError('Agrega al menos un video antes de renderizar.')
+      return
+    }
+
+    const hasErrors = clips.some((clip) => clip.status === 'error')
+    if (hasErrors) {
+      setRenderError('Elimina o reemplaza los clips con error antes de continuar.')
+      return
+    }
+
+    const pendingUploads = clips.filter((clip) => clip.status !== 'uploaded')
+    if (pendingUploads.length > 0) {
+      setRenderError('Espera a que todos los videos terminen de subir.')
+      return
+    }
+
+    setIsRendering(true)
+    setRenderError(null)
+
+    try {
+      const response = await fetch('/backend/editor/jobs', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          clips: clips.map((clip) => ({
+            upload_id: clip.uploadId as string,
+            duration: clip.duration ?? 0,
+          })),
+        }),
+      })
+
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}))
+        const message =
+          typeof errorPayload?.detail === 'string'
+            ? errorPayload.detail
+            : 'No se pudo iniciar el render. Inténtalo más tarde.'
+        throw new Error(message)
+      }
+
+      const payload = (await response.json()) as JobResponse
+      router.push(`/studio/jobs/${payload.job_id}`)
+    } catch (error) {
+      console.error('Error al renderizar', error)
+      setRenderError(
+        error instanceof Error
+          ? error.message
+          : 'Ocurrió un error inesperado al crear el trabajo.'
+      )
+    } finally {
+      setIsRendering(false)
+    }
+  }
+
+  return (
+    <section className="bg-neutral-50 pb-24 pt-16 dark:bg-brand-night">
+      <div className="container-responsive max-w-4xl space-y-10">
+        <header className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-widest text-brand-gold">
+            Editor Yaomexi
+          </p>
+          <h1 className="font-display text-4xl text-brand-jade md:text-5xl">
+            Arma tu video con clips existentes
+          </h1>
+          <p className="text-sm text-neutral-600 dark:text-neutral-300">
+            Carga videos, ordénalos en una timeline sencilla y genera un MP4
+            listo para compartir en TikTok.
+          </p>
+        </header>
+
+        <div className="rounded-3xl border border-neutral-200 bg-white/90 p-8 shadow-xl shadow-brand-night/10 dark:border-neutral-800 dark:bg-brand-night/70">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="font-display text-2xl text-brand-jade">
+                Timeline de clips
+              </h2>
+              <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                Arrastra o selecciona varios archivos de video (MP4, MOV o
+                WebM).
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept="video/mp4,video/quicktime,video/webm"
+                className="hidden"
+                onChange={handleSelectFiles}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="inline-flex items-center justify-center rounded-full border border-brand-turquoise px-5 py-2 text-sm font-semibold text-brand-turquoise transition hover:bg-brand-turquoise hover:text-white focus-visible:bg-brand-turquoise focus-visible:text-white"
+              >
+                Subir videos
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-6 space-y-4">
+            {clips.length === 0 ? (
+              <p className="rounded-2xl border border-dashed border-neutral-300 bg-white/60 p-6 text-sm text-neutral-500 dark:border-neutral-700 dark:bg-brand-night/50">
+                Aún no hay clips en la timeline. Agrega videos para comenzar a
+                construir tu historia.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {clips.map((clip, index) => (
+                  <li
+                    key={clip.localId}
+                    className="flex flex-col gap-2 rounded-2xl border border-neutral-200 bg-white/80 p-4 text-sm text-neutral-700 shadow-sm transition dark:border-neutral-700 dark:bg-brand-night/60 dark:text-neutral-200 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div className="space-y-1">
+                      <p className="font-semibold text-brand-jade">
+                        {index + 1}. {clip.file.name}
+                      </p>
+                      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                        {clip.duration ? `Duración: ${formatSeconds(clip.duration)}` : 'Calculando duración…'}
+                      </p>
+                      {clip.error && (
+                        <p className="text-xs text-brand-red" role="alert">
+                          {clip.error}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="rounded-full border border-neutral-200 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-neutral-500 dark:border-neutral-600 dark:text-neutral-400">
+                        {clip.status === 'uploaded'
+                          ? 'Listo'
+                          : clip.status === 'uploading'
+                          ? 'Subiendo'
+                          : 'Error'}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveClip(clip.localId)}
+                        className="inline-flex items-center justify-center rounded-full border border-brand-red px-4 py-1 text-xs font-semibold text-brand-red transition hover:bg-brand-red hover:text-white focus-visible:bg-brand-red focus-visible:text-white"
+                      >
+                        Quitar
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="rounded-2xl border border-neutral-200 bg-white/70 p-4 text-sm text-neutral-600 dark:border-neutral-700 dark:bg-brand-night/60 dark:text-neutral-300">
+              <p>
+                Clips totales: <strong>{clips.length}</strong>
+              </p>
+              <p>
+                Duración estimada:{' '}
+                <strong>{formatSeconds(totalDuration)}</strong>
+              </p>
+            </div>
+          </div>
+
+          {renderError && (
+            <div
+              className="mt-6 rounded-2xl border border-brand-red/40 bg-brand-red/10 p-4 text-sm text-brand-red"
+              role="alert"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <p>{renderError}</p>
+                <button
+                  type="button"
+                  onClick={handleResetError}
+                  className="text-xs font-semibold uppercase tracking-widest text-brand-red underline-offset-2 hover:underline"
+                >
+                  Entendido
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div className="mt-8 flex flex-wrap items-center justify-end gap-4">
+            <button
+              type="button"
+              onClick={handleRender}
+              disabled={isRendering || clips.length === 0}
+              className="inline-flex items-center justify-center rounded-full bg-brand-jade px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-turquoise focus-visible:bg-brand-turquoise disabled:cursor-not-allowed disabled:bg-neutral-300 disabled:text-neutral-500"
+            >
+              {isRendering ? 'Renderizando…' : 'Renderizar'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/studio/editor/page.tsx
+++ b/app/studio/editor/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+
+import { EditorClient } from './EditorClient'
+
+export const metadata: Metadata = {
+  title: 'Editor de video | Yaomexicatl Studio',
+  description:
+    'Combina clips y genera videos listos para TikTok con el Mini Estudio web de Yaomexicatl.',
+}
+
+export default function EditorPage() {
+  return <EditorClient />
+}

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { BadgeImpact } from '../../components/BadgeImpact'
-import { CreateTikTokVideoForm } from './CreateTikTokVideoForm'
 
 export const metadata: Metadata = {
   title: 'Mini Estudio | Yaomexicatl Studio',
@@ -59,11 +58,25 @@ export default function StudioPage() {
               Mini Estudio Web
             </h2>
             <p className="text-sm text-neutral-600 dark:text-neutral-300">
-              Completa los pasos para generar tu video en cuestión de minutos.
-              Puedes regresar y editar antes de enviar.
+              Inicia el nuevo editor para combinar clips, visualizar su duración
+              y generar un MP4 listo para publicar en TikTok.
             </p>
           </header>
-          <CreateTikTokVideoForm />
+          <div className="mt-8 space-y-6 text-sm text-neutral-600 dark:text-neutral-300">
+            <p>
+              ✦ Sube múltiples videos y ordénalos en una timeline sencilla.
+            </p>
+            <p>✦ Visualiza la duración estimada antes de renderizar.</p>
+            <p>✦ Obtén un trabajo de render que podrás seguir en tiempo real.</p>
+          </div>
+          <div className="mt-10 flex justify-start">
+            <Link
+              href="/studio/editor"
+              className="inline-flex items-center justify-center rounded-full bg-brand-jade px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-turquoise focus-visible:bg-brand-turquoise"
+            >
+              Ir al editor de video
+            </Link>
+          </div>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
               producto digital inspirado en la cultura prehispánica y los colibríes que la resguardan.
             </p>
             <div class="cta-group">
-              <a class="button button-primary" href="/videos/crear">Crear video de TikTok</a>
+              <a class="button button-primary" href="/studio/editor">Crear video de TikTok</a>
               <a class="button button-secondary" href="/impacto">Ver impacto</a>
             </div>
             <div class="impact-badge" id="impacto">

--- a/tests/api/test_videos.py
+++ b/tests/api/test_videos.py
@@ -1,18 +1,25 @@
 import sys
+from io import BytesIO
 from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
 import pytest_asyncio
+from starlette.datastructures import UploadFile
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from api.main import (  # noqa: E402
     JOB_KEY_PREFIX,
+    UPLOAD_KEY_PREFIX,
     CreateTikTokVideoRequest,
+    CreateTimelineJobRequest,
     JobStatusResponse,
+    TimelineClip,
     create_tiktok_video,
+    create_timeline_job,
     get_job_status,
+    upload_editor_clip,
 )
 
 
@@ -55,3 +62,30 @@ async def test_create_and_poll_job(fake_redis):
     assert isinstance(job_status, JobStatusResponse)
     assert job_status.status == "DONE"
     assert job_status.download_url and job_status.download_url.endswith(f"{job_id}.mp4")
+
+
+@pytest.mark.asyncio()
+async def test_upload_clip_and_create_timeline_job(tmp_path, fake_redis, monkeypatch):
+    from api import main as api_main  # noqa: WPS433
+
+    monkeypatch.setattr(api_main, "UPLOADS_DIR", tmp_path)
+
+    clip_file = UploadFile(filename="clip.mp4", file=BytesIO(b"fake-video"))
+    upload_response = await upload_editor_clip(file=clip_file, redis=fake_redis)
+
+    assert upload_response.upload_id
+
+    stored_clip = await fake_redis.hgetall(f"{UPLOAD_KEY_PREFIX}{upload_response.upload_id}")
+    assert stored_clip.get("path")
+
+    payload = CreateTimelineJobRequest(
+        clips=[TimelineClip(upload_id=upload_response.upload_id, duration=2.5)]
+    )
+
+    job_response = await create_timeline_job(payload, redis=fake_redis)
+    assert job_response.status == "QUEUED"
+
+    job_key = f"{JOB_KEY_PREFIX}{job_response.job_id}"
+    job_data = await fake_redis.hgetall(job_key)
+    assert job_data.get("job_type") == "timeline"
+    assert job_data.get("clips")

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from moviepy.editor import ColorClip
+from moviepy.editor import ColorClip, VideoFileClip, concatenate_videoclips
 from pydantic import BaseModel, Field
 from redis import Redis
 
@@ -16,10 +17,13 @@ logger = logging.getLogger("yaomexi.worker")
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 QUEUE_NAME = os.getenv("QUEUE_NAME", "yaomexi:videos")
 JOB_KEY_PREFIX = os.getenv("JOB_KEY_PREFIX", "video_job:")
+UPLOAD_KEY_PREFIX = os.getenv("UPLOAD_KEY_PREFIX", "editor_upload:")
 VIDEOS_DIR = Path(os.getenv("VIDEOS_DIR", "/videos"))
+UPLOADS_DIR = Path(os.getenv("UPLOADS_DIR", VIDEOS_DIR / "uploads"))
 POLL_TIMEOUT = int(os.getenv("WORKER_POLL_TIMEOUT", "10"))
 
 VIDEOS_DIR.mkdir(parents=True, exist_ok=True)
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 class TikTokVideoJob(BaseModel):
@@ -27,6 +31,16 @@ class TikTokVideoJob(BaseModel):
     template: str = Field(..., min_length=3)
     script: str = Field(..., min_length=50)
     voice: str = Field(..., min_length=3)
+
+
+class TimelineClip(BaseModel):
+    upload_id: str = Field(..., min_length=3)
+    duration: float = Field(..., gt=0)
+
+
+class TimelineJob(BaseModel):
+    job_id: str
+    clips: list[TimelineClip]
 
 
 def now_iso() -> str:
@@ -44,11 +58,44 @@ def update_job(redis: Redis, job_id: str, **fields: Any) -> None:
     )
 
 
-def render_video(job: TikTokVideoJob, destination: Path) -> None:
+def render_tiktok_video(job: TikTokVideoJob, destination: Path) -> None:
     clip = ColorClip(size=(1080, 1920), color=(20, 184, 166))
     clip = clip.set_duration(5)
     clip.write_videofile(destination.as_posix(), codec="libx264", fps=24, audio=False, logger=None)
     clip.close()
+
+
+def render_timeline_video(redis: Redis, job: TimelineJob, destination: Path) -> None:
+    video_clips: list[VideoFileClip] = []
+    try:
+        for clip in job.clips:
+            clip_key = f"{UPLOAD_KEY_PREFIX}{clip.upload_id}"
+            clip_data = redis.hgetall(clip_key)
+            clip_path = clip_data.get("path") if clip_data else None
+            if not clip_path:
+                raise ValueError(f"No se encontró el archivo para el clip {clip.upload_id}")
+
+            source = Path(clip_path)
+            if not source.exists():
+                raise ValueError(f"El archivo {clip_path} no existe")
+
+            video_clips.append(VideoFileClip(source.as_posix()))
+
+        if not video_clips:
+            raise ValueError("No hay clips para combinar")
+
+        final_clip = concatenate_videoclips(video_clips, method="compose")
+        final_clip.write_videofile(
+            destination.as_posix(),
+            codec="libx264",
+            fps=24,
+            audio_codec="aac",
+            logger=None,
+        )
+        final_clip.close()
+    finally:
+        for clip in video_clips:
+            clip.close()
 
 
 def process_job(redis: Redis, job_id: str) -> None:
@@ -57,9 +104,18 @@ def process_job(redis: Redis, job_id: str) -> None:
         logger.warning("Job %s is missing from Redis", job_id)
         return
 
+    job_type = job_data.get("job_type", "tiktok")
+
+    if job_type == "timeline":
+        process_timeline_job(redis, job_id, job_data)
+    else:
+        process_tiktok_job(redis, job_id, job_data)
+
+
+def process_tiktok_job(redis: Redis, job_id: str, job_data: dict[str, str]) -> None:
     try:
         job = TikTokVideoJob(**job_data)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         logger.exception("Job %s has invalid data: %s", job_id, exc)
         update_job(
             redis, job_id, status="FAILED", message="Datos inválidos para renderizar el video"
@@ -70,10 +126,51 @@ def process_job(redis: Redis, job_id: str) -> None:
     output_path = VIDEOS_DIR / f"{job.job_id}.mp4"
 
     try:
-        render_video(job, output_path)
+        render_tiktok_video(job, output_path)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error rendering video for job %s: %s", job.job_id, exc)
         update_job(redis, job.job_id, status="FAILED", message="No se pudo generar el video")
+        if output_path.exists():
+            output_path.unlink(missing_ok=True)
+        return
+
+    update_job(
+        redis,
+        job.job_id,
+        status="DONE",
+        download_url=f"/backend/videos/{job.job_id}.mp4",
+        message="Video listo para descarga",
+    )
+
+
+def process_timeline_job(redis: Redis, job_id: str, job_data: dict[str, str]) -> None:
+    clips_raw = job_data.get("clips") or "[]"
+    try:
+        clips_payload = json.loads(clips_raw)
+    except json.JSONDecodeError as exc:
+        logger.exception("Job %s has invalid clips payload: %s", job_id, exc)
+        update_job(
+            redis, job_id, status="FAILED", message="Clips inválidos para el editor"
+        )
+        return
+
+    try:
+        job = TimelineJob(job_id=job_id, clips=clips_payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Job %s could not be parsed: %s", job_id, exc)
+        update_job(
+            redis, job_id, status="FAILED", message="No se pudo interpretar la timeline"
+        )
+        return
+
+    update_job(redis, job_id, status="PROCESSING")
+    output_path = VIDEOS_DIR / f"{job.job_id}.mp4"
+
+    try:
+        render_timeline_video(redis, job, output_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Error rendering timeline job %s: %s", job.job_id, exc)
+        update_job(redis, job.job_id, status="FAILED", message="No se pudo combinar los clips")
         if output_path.exists():
             output_path.unlink(missing_ok=True)
         return


### PR DESCRIPTION
## Summary
- deduplicate timeline uploads in the mini studio so repeated files are ignored safely
- surface a combined validation message when incompatible or duplicate clips are skipped

## Testing
- npm run lint
- pytest tests/api/test_videos.py

------
https://chatgpt.com/codex/tasks/task_b_68d8b8ed4fa88325a6531f80b4c5eec3