### PR TITLE
Feat/fulfill api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,28 @@ Mini Estudio Web para generar videos verticales que financian la reforestación 
 
 ```bash
 docker compose up --build
+
+## API de fulfillment (FastAPI)
+
+En `app/main.py` se define un servicio FastAPI minimal con el endpoint `POST /fulfill-yaomi`.
+Este endpoint espera un JSON con `email` (correo de destino) y `productId` (ID del producto) y envía un enlace de descarga al correo usando la API de Resend.
+
+### Cómo ejecutar localmente
+
+1. Instala las dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Define la variable de entorno `RESEND_API_KEY` con tu clave de Resend.
+
+3. Ejecuta el servidor:
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 10000
+```
+
+### Despliegue en Render
+
+Se incluye un archivo `render.yaml` con la configuración mínima para desplegar este servicio en Render como tipo `web`. Render instalará las dependencias y arrancará Uvicorn con el comando anterior.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+import os, requests
+
+RESEND_KEY = os.getenv("RESEND_API_KEY")
+PRODUCTS = {
+  "guardian-colibri": "https://github.com/<org>/<repo>/releases/download/v1.0/guardian-colibri.zip"
+}
+
+class Order(BaseModel):
+    email: EmailStr
+    productId: str
+
+app = FastAPI()
+
+@app.post("/fulfill-yaomi")
+def fulfill(order: Order):
+    url = PRODUCTS.get(order.productId)
+    if not url:
+        raise HTTPException(status_code=404, detail="Producto no encontrado")
+
+    # Enviar email (Resend)
+    r = requests.post(
+      "https://api.resend.com/emails",
+      headers={"Authorization": f"Bearer {RESEND_KEY}", "Content-Type":"application/json"},
+      json={"from":"Yaomexicatl <no-reply@tu-dominio>",
+            "to":[order.email],
+            "subject":"Tu descarga Yaomexicatl",
+            "html": f"¡Gracias por apoyar! Descarga tu pack: <a href='{url}'>aquí</a>."}
+    )
+    if r.status_code >= 300:
+        raise HTTPException(status_code=500, detail="Error al enviar email")
+
+    return {"ok": True, "downloadUrl": url}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,4 @@
+services:
+  - type: web
+    build: "pip install -r requirements.txt"
+    start: "uvicorn app.main:app --host 0.0.0.0 --port 10000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.*
+uvicorn[standard]==0.30.*
+requests==2.*


### PR DESCRIPTION
This pull request adds a minimal FastAPI service to handle Yaomexicatl product fulfillment.

- Added `app/main.py` defining a FastAPI app with an endpoint `/fulfill-yaomi` that sends download links to customers via the Resend API.
- Added `requirements.txt` listing dependencies: FastAPI, uvicorn with standard extras, and requests.
- Added `render.yaml` for deployment on Render specifying build and start commands.
- Updated README with instructions on how to run the service and explanation of the fulfillment API.

Please review and merge this feature branch into main.